### PR TITLE
config.neon: setup default prefixes

### DIFF
--- a/config/config.neon
+++ b/config/config.neon
@@ -14,6 +14,7 @@ sentry:
 
 	client:
 		dsn: "https://FILLME@FILLME.ingest.sentry.io/1FILLME"
+		prefixes: [%rootDir%]
 
 # ======================================
 # Services =============================


### PR DESCRIPTION
I believe you never want to see absolute path on the filesystem, but relative to the project root.