### PR TITLE
Replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## What changed
- replaced `-p phpdbg` with `-p php` in the `coverage` Makefile target
- kept the change scoped to the single coverage command

## Why
- phpdbg is no longer required for this coverage invocation, and using plain `php` keeps the target aligned with the requested maintenance update
- relates to contributte/contributte#73